### PR TITLE
changes to get behavior closer to restaurant demo

### DIFF
--- a/artifacts/Restaurants/Calendar.js
+++ b/artifacts/Restaurants/Calendar.js
@@ -26,10 +26,8 @@ defineParticle(({DomParticle}) => {
   }
   [${host}] .scroll-container {
     position: relative;
-    /*
-    height: 280px;
+    height: 10em;
     overflow-y: auto;
-    */
   }
   [${host}] .hour-row {
     display: flex;

--- a/artifacts/Restaurants/Calendar.manifest
+++ b/artifacts/Restaurants/Calendar.manifest
@@ -12,4 +12,5 @@ particle Calendar in 'Calendar.js'
   Calendar(inout [Event] event)
   affordance dom
   consume action
+  consume modifier
   description `Calendar`

--- a/artifacts/Restaurants/ReservationAnnotation.manifest
+++ b/artifacts/Restaurants/ReservationAnnotation.manifest
@@ -7,11 +7,10 @@
 # http://polymer.github.io/PATENTS.txt
 
 import 'Restaurant.manifest'
+import 'Event.manifest'
 
-particle RestaurantList in 'RestaurantList.js'
-  RestaurantList(in [Restaurant] list, inout [Restaurant] selected)
+particle ReservationAnnotation in 'ReservationForm.js'
+  ReservationAnnotation(in [Restaurant] list, inout [Event] event)
   affordance dom
-  consume master
-    provide set of annotation
-      view list
-  description `Show ${list}`
+  consume set of annotation
+  description `Reservation Details`

--- a/artifacts/Restaurants/ReservationForm.js
+++ b/artifacts/Restaurants/ReservationForm.js
@@ -29,12 +29,21 @@ defineParticle(({DomParticle}) => {
     padding: 4px;
     font-size: 14px;
   }
+  [${host}] [times] {
+    display: flex;
+    justify-content: space-around
+  }
 </style>
   `;
 
   let template = `
 ${styles}
-<div ${host}>
+<div ${host} id={{subId}}>
+  <div>{{timePicker}}</div>
+  <div times>{{availableTimes}}</div>
+</div>
+
+<template time-picker>
   <select>
     <option>1 person</option>
     <option selected>2 people</option>
@@ -44,7 +53,11 @@ ${styles}
   </select>
 
   <input type="datetime-local" value="{{date}}" on-change="_onDateChanged">
-</div>
+</template>
+
+<template available-times>
+  <button disabled$={{notAvailable}}>{{time}}</button>
+</template>
     `.trim();
 
   return class extends DomParticle {
@@ -61,10 +74,70 @@ ${styles}
       local.setMinutes(date.getMinutes() - date.getTimezoneOffset());
       return local.toJSON().slice(0,16);
     }
+    makeUpReservationTimes(id, partySize, date, n) {
+      // Start at (n-1)/2 before the desired reservation time
+      let t = new Date((date ? new Date(date) : new Date()).getTime() - (n-1)/2*3600*1000);
+      let hour = (t.getHours()) % 24;
+      let minute = t.getMinutes() > 30 ? "30" : "00";
+
+      // Seed per restaurant and day
+      let seed = parseInt(id.substr(0, 8), 16);
+      let ts = t.getTime();
+      ts = ts - (ts % 86400000); // Round to closest day
+
+      let result = [];
+
+      while (n--) {
+        // This seems somewhat balanced
+        let notAvailable = (seed*(hour*2+minute/30)*(ts/86400000))%10 <= partySize;
+
+        result.push({
+          time: `${hour}:${minute}`,
+          notAvailable
+        });
+
+        // Increment time slot
+        if (minute == "30") {
+          hour = (hour + 1) % 24;
+          minute = "00";
+        } else {
+          minute = "30";
+        }
+      }
+
+      return result;
+    }
     _render(props, state) {
+      console.log("rendering", props, state);
       const event = props.event;
+      const selected = props.selected;
+      const selectedRestaurant = selected && selected.length && selected[selected.length-1];
+      let date = event && event.length && event[event.length-1].rawData.startDate || ''
+      if (selectedRestaurant) {
+        return this._renderSingle(selectedRestaurant, date, 2, true);
+      } else {
+        return this._renderList(props.list, date, 2);
+      }
+    }
+    _renderSingle(restaurant, date, partySize, showTimePicker) {
+      let restaurantId = restaurant.rawData.id || "";
+      let times = this.makeUpReservationTimes(restaurantId, partySize, date, 5);
+      console.log("times", restaurantId, times);
       return {
-        date: event && event.length && event[event.length-1].rawData.startDate || ''
+        subId: restaurantId,
+        timePicker: {
+          $template: 'time-picker',
+          models: showTimePicker ? [{ date }] : []
+        },
+        availableTimes: {
+          $template: 'available-times',
+          models: times
+        }
+      }
+    }
+    _renderList(list, date, partySize) {
+      return {
+        items: list.map(restaurant => this._renderSingle(restaurant, date, partySize, false))
       }
     }
     _onDateChanged(e, state) {

--- a/artifacts/Restaurants/ReservationForm.js
+++ b/artifacts/Restaurants/ReservationForm.js
@@ -116,7 +116,7 @@ ${styles}
       if (selectedRestaurant) {
         return this._renderSingle(selectedRestaurant, date, 2, true);
       } else {
-        return this._renderList(props.list, date, 2);
+        return this._renderList(props.list || [], date, 2);
       }
     }
     _renderSingle(restaurant, date, partySize, showTimePicker) {

--- a/artifacts/Restaurants/RestaurantDetail.manifest
+++ b/artifacts/Restaurants/RestaurantDetail.manifest
@@ -13,4 +13,5 @@ particle RestaurantDetail in 'RestaurantDetail.js'
   affordance dom
   consume detail
     provide action
+      view selected
   description `Show Restaurant Details`

--- a/artifacts/Restaurants/RestaurantDetail.manifest
+++ b/artifacts/Restaurants/RestaurantDetail.manifest
@@ -13,5 +13,4 @@ particle RestaurantDetail in 'RestaurantDetail.js'
   affordance dom
   consume detail
     provide action
-      view selected
   description `Show Restaurant Details`

--- a/artifacts/Restaurants/RestaurantList.js
+++ b/artifacts/Restaurants/RestaurantList.js
@@ -92,6 +92,7 @@ defineParticle(({DomParticle}) => {
   }
 </style>
 <div ${host}>
+  <div slotid="modifier"></div>
   <div class="header">Found <span>{{count}}</span> item(s).</div>
   <x-list items="{{items}}"><template>${selectable}</template></x-list>
 </div>

--- a/artifacts/Restaurants/RestaurantList.js
+++ b/artifacts/Restaurants/RestaurantList.js
@@ -21,6 +21,7 @@ defineParticle(({DomParticle}) => {
   </div>
   <div class="cover"><img class="photo" src="{{photo}}"></div>
 </div>
+<div slotid="annotation" subid$="{{id}}">
   `.trim();
 
   let selectable = `

--- a/artifacts/Restaurants/RestaurantList.manifest
+++ b/artifacts/Restaurants/RestaurantList.manifest
@@ -12,6 +12,7 @@ particle RestaurantList in 'RestaurantList.js'
   RestaurantList(in [Restaurant] list, inout [Restaurant] selected)
   affordance dom
   consume master
+    provide modifier
     provide set of annotation
       view list
   description `Show ${list}`

--- a/artifacts/Restaurants/recipes.manifest
+++ b/artifacts/Restaurants/recipes.manifest
@@ -20,11 +20,14 @@ import 'Restaurant.manifest'
 view RestaurantSelections of [Restaurant] in '../Things/empty.json'
 
 import 'ReservationForm.manifest'
+import 'ReservationAnnotation.manifest'
 import 'Calendar.manifest'
 
 recipe
   create as event
   ReservationForm
+    event = event
+  ReservationAnnotation
     event = event
 
 recipe


### PR DESCRIPTION
This implements
 * randomly generated available times as buttons
 * show those (and not the time/people picker) on results list for each result
 * show calendar on results list
 * shrink calendar

TODO:
 * scroll within calendar
 * people picker (incl. as it's own particle, consuming 'modifier', which appears in the list at the top)
 * maybe: make calendar expandable?
 * making it a lot prettier :)

I couldn't figure out how to scroll and overflowed div with pure CSS. We might need a custom element that translates a property to .scrollTop and add that to the set of whitelisted elements.

