### PR TITLE
correct types to match our usage

### DIFF
--- a/0.3/Events/Event.schema
+++ b/0.3/Events/Event.schema
@@ -10,7 +10,7 @@ schema Event
   normative
     Text endDate
     Text startDate
-    Text participants
+    Number participants
     Text description
     Text availability
     Text humanReadableTime

--- a/0.3/PlaidAccounts/PlaidAccount.schema
+++ b/0.3/PlaidAccounts/PlaidAccount.schema
@@ -13,11 +13,11 @@ schema PlaidAccount
     Text user
     Text name
   optional
-    Text balanceAvailable
-    Text balanceCurrent
+    Number balanceAvailable
+    Number balanceCurrent
     Text institution_type
     Text metaName
     Text metaNumber
-    Text metaLimit
+    Number metaLimit
     Text subtype
     Text type

--- a/0.3/PlaidAccounts/PlaidTransaction.schema
+++ b/0.3/PlaidAccounts/PlaidTransaction.schema
@@ -10,19 +10,24 @@ schema PlaidTransaction
   normative
     Text account
     Text id
-    Text amount
+    Number amount
     Text date
     Text name
   optional
     Text metaLocationAddress
     Text metaLocationCity
     Text metaLocationState
-    Text pending
+    Text metaLocationZip
+    Number metaLocationCoordinatesLat
+    Number metaLocationCoordinatesLon
+    Boolean pending
     Text typePrimary
     Text category0
     Text category1
+    Text category2
     Text category_id
-    Text scoreLocationAddress
-    Text scoreLocationCity
-    Text scoreLocationState
-    Text scoreName
+    Number scoreLocationAddress
+    Number scoreLocationCity
+    Number scoreLocationState
+    Number scoreLocationZip
+    Number scoreName

--- a/0.3/Restaurants/Restaurant.schema
+++ b/0.3/Restaurants/Restaurant.schema
@@ -15,5 +15,5 @@ schema Restaurant extends Thing
     Text icon
     Text photos
     Text photo
-    Text rating
+    Number rating
     Text address

--- a/0.3/Restaurants/source/FindRestaurants.js
+++ b/0.3/Restaurants/source/FindRestaurants.js
@@ -58,7 +58,6 @@ defineParticle(({DomParticle, resolver}) => {
           reference: p.reference,
           name: p.name,
           icon: p.icon,
-          photos: p.photos,
           address: p.vicinity,
           rating: p.rating,
           identifier: p.place_id,


### PR DESCRIPTION
The type system has grown more robust, and now validates that schema and JS
types match (for instance, rating<Number> cannot be assigned a JS value of
'12').
This brings some elements of our schema in line with how we're using them in
standard flows. None of the fields I've changed appear in schema.org.