### PR TITLE
Uses geolocation in the restaurants demo

### DIFF
--- a/0.3/Places/ExtractLocation.manifest
+++ b/0.3/Places/ExtractLocation.manifest
@@ -1,0 +1,14 @@
+# @license
+# Copyright (c) 2018 Google Inc. All rights reserved.
+# This code may only be used under the BSD style license found at
+# http://polymer.github.io/LICENSE.txt
+# Code distributed by Google as part of this project is also
+# subject to an additional IP rights grant found at
+# http://polymer.github.io/PATENTS.txt
+
+import 'https://$cdn/artifacts/People/Person.schema'
+import 'https://$cdn/artifacts/Things/GeoCoordinates.schema'
+
+particle ExtractLocation in 'source/ExtractLocation.js'
+  ExtractLocation(in Person person, out GeoCoordinates location)
+  description `extract ${person}'s location`

--- a/0.3/Places/source/ExtractLocation.js
+++ b/0.3/Places/source/ExtractLocation.js
@@ -1,0 +1,24 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+"use strict";
+
+defineParticle(({DomParticle}) => {
+  return class ExtractLocation extends DomParticle {
+    _willReceiveProps(props, state, lastProps) {
+      if (props.person && props.person.name && props.person.location
+          && JSON.stringify(props.person.location) !==
+          JSON.stringify(lastProps.person && lastProps.person.location)) {
+        let {latitude, longitude} = props.person.location;
+        let location = this._views.get('location');
+        location.set(new location.entityClass(
+          {latitude, longitude, name: `${props.person.name}'s location`}));
+      }
+    }
+  }
+});

--- a/0.3/Places/source/ExtractLocation.js
+++ b/0.3/Places/source/ExtractLocation.js
@@ -14,8 +14,8 @@ defineParticle(({DomParticle}) => {
       if (props.person && props.person.name && props.person.location
           && JSON.stringify(props.person.location) !==
           JSON.stringify(lastProps.person && lastProps.person.location)) {
-        let {latitude, longitude} = props.person.location;
-        let location = this._views.get('location');
+        const {latitude, longitude} = props.person.location;
+        const location = this._views.get('location');
         location.set(new location.entityClass(
           {latitude, longitude, name: `${props.person.name}'s location`}));
       }

--- a/0.3/Restaurants/FindRestaurants.manifest
+++ b/0.3/Restaurants/FindRestaurants.manifest
@@ -6,12 +6,13 @@
 # subject to an additional IP rights grant found at
 # http://polymer.github.io/PATENTS.txt
 
+import 'https://$cdn/artifacts/Things/GeoCoordinates.schema'
 import 'Restaurant.schema'
 
 particle FindRestaurants in 'source/FindRestaurants.js'
-  FindRestaurants(inout [Restaurant] restaurants)
+  FindRestaurants(in GeoCoordinates location, inout [Restaurant] restaurants)
   affordance dom
   consume root
     provide masterdetail
       view restaurants
-  description `find restaurants in San Francisco`
+  description `find restaurants near ${location.name}`

--- a/0.3/Restaurants/Restaurants.recipes
+++ b/0.3/Restaurants/Restaurants.recipes
@@ -9,11 +9,18 @@ import 'FindRestaurants.manifest'
 import 'RestaurantMasterDetail.manifest'
 import 'RestaurantList.manifest'
 import 'RestaurantDetail.manifest'
+import '../Places/ExtractLocation.manifest'
 
 recipe
+  use #user as person
+  create as location
   create as selected
   create #restaurants #nosync as restaurants
+  ExtractLocation
+    person <- person
+    location -> location
   FindRestaurants
+    location <- location
     restaurants = restaurants
   RestaurantMasterDetail
     list <- restaurants

--- a/0.3/Restaurants/source/FindRestaurants.js
+++ b/0.3/Restaurants/source/FindRestaurants.js
@@ -35,14 +35,13 @@ defineParticle(({DomParticle, resolver}) => {
     }
     _fetchPlaces(location) {
       this._setState({count: -1});
-      let loc = location ? `${location.latitude},${location.longitude}`
+      const loc = location ? `${location.latitude},${location.longitude}`
           : `37.7610927,-122.4208173`; // Using San Francisco as a fallback.
-      let radius = `1000`;
-      let type = `restaurant`;
+      const radius = `1000`;
+      const type = `restaurant`;
       fetch(`${placesService}?location=${loc}&radius=${radius}&type=${type}`)
         .then(response => response.json())
-        .then(places => this._receivePlaces(places))
-        ;
+        .then(places => this._receivePlaces(places));
     }
     _receivePlaces(places) {
       //console.log("_receivePlaces = ", places.results);

--- a/0.3/Restaurants/source/FindRestaurants.js
+++ b/0.3/Restaurants/source/FindRestaurants.js
@@ -29,15 +29,14 @@ defineParticle(({DomParticle, resolver}) => {
       return template;
     }
     _willReceiveProps(props, state) {
-      if (props.restaurants && !state.count) {
-        this._fetchPlaces();
+      if (props.restaurants && props.location && !state.count) {
+        this._fetchPlaces(props.location);
       }
     }
-    _fetchPlaces() {
+    _fetchPlaces(location) {
       this._setState({count: -1});
-      //let loc = `55.6711876,12.4537421`;
-      //let loc = `55.6786282,12.3155385`;
-      let loc = `37.7610927,-122.4208173`;
+      let loc = location ? `${location.latitude},${location.longitude}`
+          : `37.7610927,-122.4208173`; // Using San Francisco as a fallback.
       let radius = `1000`;
       let type = `restaurant`;
       fetch(`${placesService}?location=${loc}&radius=${radius}&type=${type}`)


### PR DESCRIPTION
Introduces a particle to extract location from the user and uses this location to personalize the restaurants list. Can be overridden with Chrome Dev Tools ("More Tools -> Sensors").