### PR TITLE
replace "view" in manifests with "store" and "handle"

### DIFF
--- a/0.2/Accounts/AccountsMasterDetail.manifest
+++ b/0.2/Accounts/AccountsMasterDetail.manifest
@@ -13,4 +13,4 @@ particle AccountsMasterDetail in 'https://$cdn/artifacts/Things/source/MasterDet
   consume root
     provide master
     provide detail
-      view selected
+      handle selected

--- a/0.2/Messages/Messages.recipes
+++ b/0.2/Messages/Messages.recipes
@@ -11,7 +11,7 @@ import 'ShowChatMessages.manifest'
 import 'ComposeMessage.manifest'
 
 # bootstrap chat view
-#view Messages of [Message] #chat in 'chat.json'
+#store Messages of [Message] #chat in 'chat.json'
 
 recipe
   create #chat as messages

--- a/0.2/Messages/ShowChatMessages.manifest
+++ b/0.2/Messages/ShowChatMessages.manifest
@@ -15,4 +15,4 @@ particle ShowChatMessages in 'source/ShowChatMessages.js'
     provide preamble
     provide compose
     provide set of custom_message
-      view messages
+      handle messages

--- a/0.2/PlaidAccounts/PlaidAccounts.recipes
+++ b/0.2/PlaidAccounts/PlaidAccounts.recipes
@@ -6,10 +6,10 @@
 # http://polymer.github.io/PATENTS.txt
 
 import 'PlaidAccount.schema'
-view PlaidAccounts of [PlaidAccount] in 'accounts.json'
+store PlaidAccounts of [PlaidAccount] in 'accounts.json'
 
 import 'PlaidTransaction.schema'
-view PlaidTransactions of [PlaidTransaction] in 'transactions.json'
+store PlaidTransactions of [PlaidTransaction] in 'transactions.json'
 
 import 'PlaidAccountsMasterDetail.manifest'
 import 'PlaidAccountsList.manifest'

--- a/0.2/PlaidAccounts/PlaidAccountsMasterDetail.manifest
+++ b/0.2/PlaidAccounts/PlaidAccountsMasterDetail.manifest
@@ -13,4 +13,4 @@ particle PlaidAccountsMasterDetail in 'https://$cdn/artifacts/Things/source/Mast
   consume root
     provide master
     provide detail
-      view selected
+      handle selected

--- a/0.2/Points/Points.recipes
+++ b/0.2/Points/Points.recipes
@@ -7,7 +7,7 @@
 # http://polymer.github.io/PATENTS.txt
 
 import 'Point.schema'
-view Points of [Point] #points in 'points.json'
+store Points of [Point] #points in 'points.json'
 
 import 'Chart2d.manifest'
 recipe

--- a/0.2/Products/Products-no-extension.recipes
+++ b/0.2/Products/Products-no-extension.recipes
@@ -5,13 +5,13 @@
 # subject to an additional IP rights grant found at
 # http://polymer.github.io/PATENTS.txt
 
-view Wishlist of [Product] in 'data/wishlist.json'
+store Wishlist of [Product] in 'data/wishlist.json'
   description `Claire's wishlist`
 
-view PageProducts of [Product] in 'data/products.json'
+store PageProducts of [Product] in 'data/products.json'
   description `Products from your browsing context`
 
-view Somebody of Person in 'data/people.json'
+store Somebody of Person in 'data/people.json'
 
 import 'https://$cdn/artifacts/Products/ShowProducts.manifest'
 import 'https://$cdn/artifacts/Products/Chooser.manifest'

--- a/0.2/Products/Products.recipes
+++ b/0.2/Products/Products.recipes
@@ -5,8 +5,8 @@
 # subject to an additional IP rights grant found at
 # http://polymer.github.io/PATENTS.txt
 
-view DefaultProducts of [Product] #shortlist in 'data/empty.json'
-view Somebody of Person in 'data/people.json'
+store DefaultProducts of [Product] #shortlist in 'data/empty.json'
+store Somebody of Person in 'data/people.json'
 
 import 'https://$cdn/artifacts/Products/GiftList.manifest'
 import 'https://$cdn/artifacts/Products/Arrivinator.manifest'

--- a/0.2/Products/makeawish.recipes
+++ b/0.2/Products/makeawish.recipes
@@ -8,7 +8,7 @@
 import 'https://$cdn/artifacts/Products/Chooser.manifest'
 import 'https://$cdn/artifacts/Products/ShowProducts.manifest'
 
-view WishlistCandidates of [Product] in 'data/wishlist_candidates.json'
+store WishlistCandidates of [Product] in 'data/wishlist_candidates.json'
   description `wishlist candidates`
 
 # Make a wish

--- a/0.3/Accounts/Accounts.recipes
+++ b/0.3/Accounts/Accounts.recipes
@@ -6,7 +6,7 @@
 //http://polymer.github.io/PATENTS.txt
 
 import 'Account.schema'
-view Accounts of [Account] in 'accounts.json'
+store Accounts of [Account] in 'accounts.json'
 
 import 'AccountsMasterDetail.manifest'
 import 'AccountsList.manifest'

--- a/0.3/Accounts/AccountsMasterDetail.manifest
+++ b/0.3/Accounts/AccountsMasterDetail.manifest
@@ -13,4 +13,4 @@ particle AccountsMasterDetail in 'https://$cdn/artifacts/Common/source/MasterDet
   consume root
     provide master
     provide detail
-      view selected
+      handle selected

--- a/0.3/PlaidAccounts/PlaidAccounts.recipes
+++ b/0.3/PlaidAccounts/PlaidAccounts.recipes
@@ -6,10 +6,10 @@
 // http://polymer.github.io/PATENTS.txt
 
 import 'data/PlaidAccount.schema'
-view PlaidAccounts of [PlaidAccount] in 'data/accounts.json'
+store PlaidAccounts of [PlaidAccount] in 'data/accounts.json'
 
 import 'data/PlaidTransaction.schema'
-view PlaidTransactions of [PlaidTransaction] in 'data/transactions.json'
+store PlaidTransactions of [PlaidTransaction] in 'data/transactions.json'
 
 import 'https://$cdn/artifacts/Common/List.manifest'
 import 'https://$cdn/artifacts/Common/Detail.manifest'

--- a/0.3/Points/Points.recipes
+++ b/0.3/Points/Points.recipes
@@ -7,7 +7,7 @@
 //http://polymer.github.io/PATENTS.txt
 
 import 'Point.schema'
-view Points of [Point] #points in 'points.json'
+store Points of [Point] #points in 'points.json'
 
 import 'Chart2d.manifest'
 recipe


### PR DESCRIPTION
Scott, I'm going to deprecate the `view` syntax in manifest parser. I see that these are all 0.2 and 0.3 - are they worth updating, or shall i just leave them as is? Thanks.